### PR TITLE
Reduce usage of QApplication::processEvents

### DIFF
--- a/src/mainmenu.cpp
+++ b/src/mainmenu.cpp
@@ -148,13 +148,15 @@ void MainMenu::ReadBackupDate(char op){
 }
 
 
+void MainMenu::PrepareScan()
+{
+    Window->ui->GameList->clear();                  // Clearing the list beforehand
+    Window->ui->ScanningLabel->setVisible(true);    // Showing the scan message
+}
+
 // Functions that scan folders for content
 // For Backup Mode - scans Steam folder
 void MainMenu::BackupScan(){
-    Window->ui->GameList->clear();                  // Clearing the list beforehand
-    Window->ui->ScanningLabel->setVisible(true);    // Showing the scan message
-    App->processEvents();                           // Updating GUI
-
     // Starting scan process based on option:
     // Saves
     if (MainMenu::ProcessOp == 'S'){
@@ -249,9 +251,6 @@ void MainMenu::BackupScan(){
 
 // For Restore Mode - scans backup subfolders
 void MainMenu::RestoreScan(){
-    Window->ui->GameList->clear();                  // Clearing the list beforehand
-    Window->ui->ScanningLabel->setVisible(true);    // Showing the scan message
-    App->processEvents();                           // Updating GUI
     bool done = false;                              // Setting boolean for scanning
 
     // Starting scan process based on option:

--- a/src/mainmenu.h
+++ b/src/mainmenu.h
@@ -25,6 +25,7 @@ class MainMenu {
         static void LockUnlock();
         static void SwitchMode(char mode, char op);
         static void BackupScan();
+        static void PrepareScan();
         static void RestoreScan();
         static void OrganizeGameList();
         static void CheckUncheck(bool check);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -18,6 +18,7 @@ accompanying COPYING file for more details.
 #include <QMessageBox>
 #include <QThread>
 #include <QObject>
+#include <QTimer>
 
 // Program-specific libs
 #include "db.h"
@@ -120,14 +121,19 @@ void MainWindow::UpdateTotalSize(){
     if (MainMenu::OneItemChecked()){                                                // If at least one item has been checked:
         Window->ui->TotalSizeLabel->setText("Calculating\nsize...");                // Update size label
         Window->ui->StartBtn->setDisabled(true);                                    // Disable the Start button for calculation
-        App->processEvents();                                                       // Let the UI settle in
-        MainMenu::CheckTotalSize();                                                 // Check total size of operation
-        Window->ui->StartBtn->setDisabled(false);                                   // Enable the Start button again
+        QTimer::singleShot(0, Window, SLOT(ProcessTotalSize()));
     } else {                                                                        // If no item has been checked:
         Window->ui->TotalSizeLabel->setText("");                                    // "Hide" the size label
         Window->ui->StartBtn->setDisabled(true);                                    // Disable the Start button
     }
 }
+
+void MainWindow::ProcessTotalSize()
+{
+    MainMenu::CheckTotalSize();                                                     // Check total size of operation
+    Window->ui->StartBtn->setDisabled(false);                                       // Enable the Start button again
+}
+
 
 //-----------------------------------------------------------------------------------------------------------
 // FUNCTION CALLS - MAIN MENU
@@ -138,46 +144,54 @@ void MainWindow::UpdateTotalSize(){
 void MainWindow::on_BackupScanSaveBtn_clicked(){        // Backup Saves
     MainMenu::SwitchMode('B', 'S');
     Window->ui->StartBtn->setDisabled(true);
-    MainMenu::BackupScan();
-    Window->ui->StartBtn->setDisabled(false);
-    MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
+    MainMenu::PrepareScan();
+    QTimer::singleShot(0, this, SLOT(ProcessBackup()));
 }
 
 void MainWindow::on_BackupScanConfigBtn_clicked(){      // Backup Configs
     MainMenu::SwitchMode('B', 'C');
     Window->ui->StartBtn->setDisabled(true);
-    MainMenu::BackupScan();
-    Window->ui->StartBtn->setDisabled(false);
-    MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
+    MainMenu::PrepareScan();
+    QTimer::singleShot(0, this, SLOT(ProcessBackup()));
 }
 
 void MainWindow::on_BackupScanGameBtn_clicked(){        // Backup Games
     MainMenu::SwitchMode('B', 'G');
     Window->ui->StartBtn->setDisabled(true);
-    MainMenu::BackupScan();
-    Window->ui->StartBtn->setDisabled(false);
-    MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
+    MainMenu::PrepareScan();
+    QTimer::singleShot(0, this, SLOT(ProcessBackup()));
 }
 
 void MainWindow::on_RestoreScanSaveBtn_clicked(){       // Restore Saves
     MainMenu::SwitchMode('R', 'S');
     Window->ui->StartBtn->setDisabled(true);
-    MainMenu::RestoreScan();
-    Window->ui->StartBtn->setDisabled(false);
-    MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
+    MainMenu::PrepareScan();
+    QTimer::singleShot(0, this, SLOT(ProcessRestore()));
 }
 
 void MainWindow::on_RestoreScanConfigBtn_clicked(){     // Restore Configs
     MainMenu::SwitchMode('R', 'C');
     Window->ui->StartBtn->setDisabled(true);
-    MainMenu::RestoreScan();
-    Window->ui->StartBtn->setDisabled(false);
-    MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
+    MainMenu::PrepareScan();
+    QTimer::singleShot(0, this, SLOT(ProcessRestore()));
 }
 
 void MainWindow::on_RestoreScanGameBtn_clicked(){       // Restore Games
     MainMenu::SwitchMode('R', 'G');
     Window->ui->StartBtn->setDisabled(true);
+    MainMenu::PrepareScan();
+    QTimer::singleShot(0, this, SLOT(ProcessRestore()));
+}
+
+void MainWindow::ProcessBackup()
+{
+    MainMenu::BackupScan();
+    Window->ui->StartBtn->setDisabled(false);
+    MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
+}
+
+void MainWindow::ProcessRestore()
+{
     MainMenu::RestoreScan();
     Window->ui->StartBtn->setDisabled(false);
     MainMenu::OrganizeGameList(); MainMenu::LockUnlock();
@@ -209,7 +223,6 @@ void MainWindow::on_StartBtn_clicked(){
         MainMenu::RemoveUnchecked();                                            // Remove unchecked items from list
         ui->MainWidget->setVisible(false);                                      // Hide the main menu
         ui->ProgressWidget->setVisible(true);                                   // Show the progress menu
-        App->processEvents();                                                   // Let the UI settle in
         QThread *thread = new QThread();                                        // Create a new thread
         CopyThread->moveToThread(thread);                                       // Move backup/restore process pointer to new thread
         QObject::connect(thread, SIGNAL(started()), CopyThread, SLOT(Start())); // Connect respective signal and slot

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -121,7 +121,7 @@ void MainWindow::UpdateTotalSize(){
     if (MainMenu::OneItemChecked()){                                                // If at least one item has been checked:
         Window->ui->TotalSizeLabel->setText("Calculating\nsize...");                // Update size label
         Window->ui->StartBtn->setDisabled(true);                                    // Disable the Start button for calculation
-        QTimer::singleShot(0, Window, SLOT(ProcessTotalSize()));
+        QTimer::singleShot(1, Window, SLOT(ProcessTotalSize()));
     } else {                                                                        // If no item has been checked:
         Window->ui->TotalSizeLabel->setText("");                                    // "Hide" the size label
         Window->ui->StartBtn->setDisabled(true);                                    // Disable the Start button
@@ -145,42 +145,42 @@ void MainWindow::on_BackupScanSaveBtn_clicked(){        // Backup Saves
     MainMenu::SwitchMode('B', 'S');
     Window->ui->StartBtn->setDisabled(true);
     MainMenu::PrepareScan();
-    QTimer::singleShot(0, this, SLOT(ProcessBackup()));
+    QTimer::singleShot(1, this, SLOT(ProcessBackup()));
 }
 
 void MainWindow::on_BackupScanConfigBtn_clicked(){      // Backup Configs
     MainMenu::SwitchMode('B', 'C');
     Window->ui->StartBtn->setDisabled(true);
     MainMenu::PrepareScan();
-    QTimer::singleShot(0, this, SLOT(ProcessBackup()));
+    QTimer::singleShot(1, this, SLOT(ProcessBackup()));
 }
 
 void MainWindow::on_BackupScanGameBtn_clicked(){        // Backup Games
     MainMenu::SwitchMode('B', 'G');
     Window->ui->StartBtn->setDisabled(true);
     MainMenu::PrepareScan();
-    QTimer::singleShot(0, this, SLOT(ProcessBackup()));
+    QTimer::singleShot(1, this, SLOT(ProcessBackup()));
 }
 
 void MainWindow::on_RestoreScanSaveBtn_clicked(){       // Restore Saves
     MainMenu::SwitchMode('R', 'S');
     Window->ui->StartBtn->setDisabled(true);
     MainMenu::PrepareScan();
-    QTimer::singleShot(0, this, SLOT(ProcessRestore()));
+    QTimer::singleShot(1, this, SLOT(ProcessRestore()));
 }
 
 void MainWindow::on_RestoreScanConfigBtn_clicked(){     // Restore Configs
     MainMenu::SwitchMode('R', 'C');
     Window->ui->StartBtn->setDisabled(true);
     MainMenu::PrepareScan();
-    QTimer::singleShot(0, this, SLOT(ProcessRestore()));
+    QTimer::singleShot(1, this, SLOT(ProcessRestore()));
 }
 
 void MainWindow::on_RestoreScanGameBtn_clicked(){       // Restore Games
     MainMenu::SwitchMode('R', 'G');
     Window->ui->StartBtn->setDisabled(true);
     MainMenu::PrepareScan();
-    QTimer::singleShot(0, this, SLOT(ProcessRestore()));
+    QTimer::singleShot(1, this, SLOT(ProcessRestore()));
 }
 
 void MainWindow::ProcessBackup()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -50,6 +50,9 @@ class MainWindow : public QMainWindow {
         void on_StartBtn_clicked();
         void on_CancelBtn_clicked();
         void on_MenuBtn_clicked();
+        void ProcessBackup();
+        void ProcessRestore();
+        void ProcessTotalSize();
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Looking at the source code, the reliance on QApplication::processEvents stuck out as a bad idea. I removed all but one call with single shot timers. As a side effect, using that approach has made SLSK faster for the routines that were changed.